### PR TITLE
replace pygame.thread.Thread with threading.Thread

### DIFF
--- a/src/game_func.py
+++ b/src/game_func.py
@@ -1,5 +1,5 @@
 import pygame
-from pygame.threads import Thread
+from threading import Thread
 
 import src.load_resources as lr
 from main import main_menu


### PR DESCRIPTION
It's just a weird alias, there's nothing special about the pygame version